### PR TITLE
Allow to edit spongeurl var and forgeurl var at runtime

### DIFF
--- a/sponge-forge/scripts/start.sh
+++ b/sponge-forge/scripts/start.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+export FORGE_URL="http://files.minecraftforge.net/maven/net/minecraftforge/forge/${FORGE_VERSION}/forge-${FORGE_VERSION}-installer.jar"
+export SPONGE_URL="http://files.minecraftforge.net/maven/org/spongepowered/spongeforge/${SPONGE_VERSION}/spongeforge-${SPONGE_VERSION}.jar"
+export EXECUTABLE_JAR="forge-${FORGE_VERSION}-universal.jar"
 
 if [ ! -f "/forge/${EXECUTABLE_JAR}" ]; then
 	cd /forge


### PR DESCRIPTION
You can't edit spongeversion and forgeversion if you didn't re set url var in the start.sh script.

Here the fix